### PR TITLE
Add `open` designation to Determinate layers

### DIFF
--- a/Determinate/CircularProgressView.swift
+++ b/Determinate/CircularProgressView.swift
@@ -12,9 +12,9 @@ import Cocoa
 @IBDesignable
 open class CircularProgressView: DeterminateAnimation {
 
-    var backgroundCircle = CAShapeLayer()
-    var progressLayer = CAShapeLayer()
-    var percentLabelLayer = CATextLayer()
+    open var backgroundCircle = CAShapeLayer()
+    open var progressLayer = CAShapeLayer()
+    open var percentLabelLayer = CATextLayer()
 
     @IBInspectable open var strokeWidth: CGFloat = -1 {
         didSet {

--- a/Determinate/ProgressBar.swift
+++ b/Determinate/ProgressBar.swift
@@ -12,8 +12,8 @@ import Cocoa
 @IBDesignable
 open class ProgressBar: DeterminateAnimation {
 
-    var borderLayer = CAShapeLayer()
-    var progressLayer = CAShapeLayer()
+    open var borderLayer = CAShapeLayer()
+    open var progressLayer = CAShapeLayer()
     
     @IBInspectable open var borderColor: NSColor = NSColor.black {
         didSet {


### PR DESCRIPTION
This allows the consumer to customize them. These were being treated as “internal” so the consumer couldn’t modify them.